### PR TITLE
Add Windows release workflow

### DIFF
--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -1,0 +1,39 @@
+name: Build Windows Release
+
+on:
+  push:
+    tags:
+      - '*'
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt pyinstaller
+
+      - name: Build executable
+        run: |
+          pyinstaller --onefile --noconsole --add-data "data;data" --add-data "sounds;sounds" main.py
+          move dist\main.exe ImpuestosPagosTracker.exe
+
+      - name: Create ZIP
+        run: Compress-Archive -Path ImpuestosPagosTracker.exe -DestinationPath ImpuestosPagosTracker.zip
+
+      - name: Upload release asset
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ImpuestosPagosTracker.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- build a standalone Windows executable and zip it on tag or release events
- upload the zip file to GitHub Releases automatically

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6850c112d03883289050f91d6e0d4736